### PR TITLE
Instead of casperOnSli*m*er, the method was misspelled casperOnSli*mm*er

### DIFF
--- a/src/Canterville/Installer.php
+++ b/src/Canterville/Installer.php
@@ -61,9 +61,9 @@ class Installer
 
 
   /**
-   * Installation CasperJS on SlimmerJS
+   * Installation CasperJS on SlimerJS
    */
-  public static function casperOnSlimmer(Event $event)
+  public static function casperOnSlimer(Event $event)
   {
     self::slimer($event);
     self::casper($event);


### PR DESCRIPTION
As per https://github.com/Lawondyss/Canterville/issues/6